### PR TITLE
pwsh one-liners

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ There are many implicit opinions baked in. Here are the main ones:
 
 - `git pull --ff-only` is safer than and preferable to `git pull --rebase`.
 
+- Merges are always `--no-ff`, so the fact that a branch existed stays visible in history.
+
 - `git push` only to a feature branch you created.
 
 - Don't `push` to `dev`, `main`, or `master`; instead, create a Pull Request. Even if you otherwise have the rights to, and even for small personal projects.
@@ -120,8 +122,6 @@ There are many implicit opinions baked in. Here are the main ones:
 	While PRs are overkill for small personal projects, it is nevertheless good hygiene, does not add much extra effort, and reinforces good working habits.
 
 - Pushed history is permanent. No rebase, no amend, no force-push, no rewriting.
-
-- Merges are always `--no-ff`, so the fact that a branch existed stays visible in history.
 
 - Feature branches are short-lived: branch off, do the work, land it, delete it (local and remote).
 

--- a/git_notes_and_oneliners.md
+++ b/git_notes_and_oneliners.md
@@ -1,5 +1,6 @@
 <!-- markdownlint-disable MD007 -- Unordered list indentation -->
 <!-- markdownlint-disable MD010 -- No hard tabs -->
+<!-- markdownlint-disable MD024 -- Duplicate headings (the Bash and PowerShell sections mirror each other) -->
 <!-- markdownlint-disable MD033 -- No inline html -->
 <!-- markdownlint-disable MD055 -- Table pipe style [Expected: leading_and_trailing; Actual: leading_only; Missing trailing pipe] -->
 <!-- markdownlint-disable MD041 -- First line in a file should be a top-level heading -->
@@ -16,7 +17,7 @@ Command strings for common git tasks
 
 - [General notes](#general-notes)
 	- [Stash](#stash)
-- [Commands for common tasks](#commands-for-common-tasks)
+- [Commands for common tasks - Bash](#commands-for-common-tasks---bash)
 	- [Basics using main or master](#basics-using-main-or-master)
 		- [Clone a project and start programming with it, using aliases in ~/.ssh/config](#clone-a-project-and-start-programming-with-it-using-aliases-in-sshconfig)
 		- [Initialize an existing local project with git and push it to a new github repo](#initialize-an-existing-local-project-with-git-and-push-it-to-a-new-github-repo)
@@ -34,6 +35,24 @@ Command strings for common git tasks
 		- [Merge current local feature branch to main, and return to main](#merge-current-local-feature-branch-to-main-and-return-to-main)
 	- [Maintenance](#maintenance)
 		- [Remove a file from git AND locally](#remove-a-file-from-git-and-locally)
+- [Commands for common tasks - PowerShell](#commands-for-common-tasks---powershell)
+	- [Basics using main or master](#basics-using-main-or-master-1)
+		- [Clone a project and start programming with it, using aliases in ~/.ssh/config](#clone-a-project-and-start-programming-with-it-using-aliases-in-sshconfig-1)
+		- [Initialize an existing local project with git and push it to a new github repo](#initialize-an-existing-local-project-with-git-and-push-it-to-a-new-github-repo-1)
+		- [Reconnect to a project after renaming it remotely](#reconnect-to-a-project-after-renaming-it-remotely-1)
+	- [Regular use](#regular-use-1)
+		- [Refresh local with changes from upstream](#refresh-local-with-changes-from-upstream-1)
+		- [Push local changes to upstream](#push-local-changes-to-upstream-1)
+	- [Read-only inspection](#read-only-inspection-1)
+		- [Show what SSH keys and username git thinks you're using](#show-what-ssh-keys-and-username-git-thinks-youre-using-1)
+		- [Show diff between local state and upstream](#show-diff-between-local-state-and-upstream-1)
+	- [Branches](#branches-1)
+		- [Check out an existing branch and start using it, while preserving local changes](#check-out-an-existing-branch-and-start-using-it-while-preserving-local-changes-1)
+		- [Create a new branch and sync it to GitHub](#create-a-new-branch-and-sync-it-to-github-1)
+		- [Push current changes and switch to a different branch](#push-current-changes-and-switch-to-a-different-branch-1)
+		- [Merge current local feature branch to main, and return to main](#merge-current-local-feature-branch-to-main-and-return-to-main-1)
+	- [Maintenance](#maintenance-1)
+		- [Remove a file from git AND locally](#remove-a-file-from-git-and-locally-1)
 - [References](#references)
 
 <!-- /TOC -->
@@ -46,7 +65,7 @@ Command strings for common git tasks
 
 Care is needed with `stash apply` or `stash pop`, because if the a `git stash push` didn't succeed, then a corresponding `apply` or `pop` may use a stale set.
 
-## Commands for common tasks
+## Commands for common tasks - Bash
 
 ### Basics using main or master
 
@@ -85,7 +104,7 @@ preCount=$(git stash list | wc -l); git stash push --include-untracked -m "auto-
 #### Push local changes to upstream
 
 ~~~bash
-n8git_backup-and-publish
+gitsby saveup
 ~~~
 
 or
@@ -113,8 +132,8 @@ git fetch && echo && git status  &&  { echo; git diff HEAD @{u} | less -FRX; ech
 #### Check out an existing branch and start using it, while preserving local changes
 
 ~~~bash
-gitProj="feature|bugfix/EXISTING_BRANCH_NAME"
-[[ -n "${gitProj}" ]]  &&  { preCount=$(git stash list | wc -l); git stash push --include-untracked -m "auto-stash"; postCount=$(git stash list | wc -l); didStash=$((postCount > preCount ? 1 : 0));  git fetch origin  &&  git checkout "${gitProj}"  &&  { ((didStash)) && git stash pop || true; }  &&  echo  &&  git status  &&  echo ; }
+branchName="feature|bugfix/EXISTING_BRANCH_NAME"
+[[ -n "${branchName}" ]]  &&  { preCount=$(git stash list | wc -l); git stash push --include-untracked -m "auto-stash"; postCount=$(git stash list | wc -l); didStash=$((postCount > preCount ? 1 : 0));  git fetch origin  &&  git checkout "${branchName}"  &&  { ((didStash)) && git stash pop || true; }  &&  echo  &&  git status  &&  echo ; }
 ~~~
 
 #### Create a new branch and sync it to GitHub
@@ -142,7 +161,7 @@ branchName="feature|bugfix/EXISTING_BRANCH_NAME"
 ## Commit local changes and sync with upstream
 preCount=$(git stash list | wc -l); git stash push --include-untracked -m "auto-stash"; postCount=$(git stash list | wc -l); didStash=$((postCount > preCount ? 1 : 0)); git pull --rebase; ((didStash)) && git stash pop; git add --all && (git diff --cached --quiet || git commit) && git push -u origin HEAD; echo && git status && echo
 
-## Merge to main (assumes clean working tree — run preceding block first)
+## Merge to main (assumes clean working tree - run preceding block first)
 [[ -n "${branchName}" ]]  &&  git checkout main  &&  git pull --ff-only origin main  &&  git checkout "${branchName}"  &&  git merge main  &&  git checkout main  &&  git merge --no-ff "${branchName}"  &&  git push origin main  &&  echo  &&  git branch -vv  &&  echo  &&  git status  &&  echo
 ~~~
 
@@ -154,6 +173,125 @@ preCount=$(git stash list | wc -l); git stash push --include-untracked -m "auto-
 fileToDelete="FILE_TO_DELETE"
 [[ -n "${fileToDelete}"  &&  -e "${fileToDelete}" ]]  &&  git rm --cached -r "${fileToDelete}"  &&  git commit -m "Remove '${fileToDelete}' from tracking."  &&  git push  &&  trash "${fileToDelete}"
 ~~~
+
+## Commands for common tasks - PowerShell
+
+Same tasks as the Bash section, for PowerShell 7+ (`pwsh`) on any platform. Three things differ from Bash and are easy to trip over:
+
+- The `&&` and `||` chain operators need pwsh 7 or newer. Windows PowerShell 5.1 will not run these.
+- `@{u}` (upstream shorthand) has to be quoted as `'@{u}'`, otherwise pwsh reads `@{` as the start of a hashtable.
+- Native commands set `$LASTEXITCODE`, not `$?`-style status, so tests like "are there staged changes" check that instead.
+
+### Basics using main or master
+
+#### Clone a project and start programming with it, using aliases in ~/.ssh/config
+
+~~~pwsh
+$gitProj = 'REMOTE_REPO_NAME'
+$gitUser = 'YOUR_GIT_USER_NAME'
+if ($gitProj -and $gitUser) { git clone "git@github_${gitUser}:${gitUser}/${gitProj}.git" && Set-Location $gitProj && Write-Host '' && git remote -v && Write-Host '' && git config user.name && git config user.email && Write-Host '' }
+~~~
+
+#### Initialize an existing local project with git and push it to a new github repo
+
+~~~pwsh
+$gitProj = 'REMOTE_REPO_NAME'
+$gitUser = 'YOUR_GIT_USER_NAME'
+if ($gitProj -and $gitUser) { git init -b main && git add --all && git commit -m 'Initial commit.' && git remote add origin "git@github_${gitUser}:${gitUser}/${gitProj}.git" && git push -u origin main && Write-Host '' && git remote -v && Write-Host '' && git config user.name && git config user.email && Write-Host '' }
+~~~
+
+#### Reconnect to a project after renaming it remotely
+
+~~~pwsh
+$gitProj = 'REMOTE_REPO_NAME'
+$gitUser = 'YOUR_GIT_USER_NAME'
+if ($gitProj -and $gitUser) { git remote set-url origin "git@github_${gitUser}:${gitUser}/${gitProj}.git" }; Write-Host "`ngit will be using this contact info:"; git config user.name; git config user.email; Write-Host "`ngit remote info:"; git remote -v; Write-Host "`nSSH login test:"; ssh -T git@github.com; Write-Host ''; git status; Write-Host ''
+~~~
+
+### Regular use
+
+#### Refresh local with changes from upstream
+
+~~~pwsh
+$preCount = @(git stash list).Count; git stash push --include-untracked -m 'auto-stash'; $didStash = (@(git stash list).Count -gt $preCount); git pull --ff-only; if ($didStash) { git stash pop }; Write-Host ''; git status; Write-Host ''
+~~~
+
+#### Push local changes to upstream
+
+~~~pwsh
+gitsby.ps1 saveup
+~~~
+
+or
+
+~~~pwsh
+$preCount = @(git stash list).Count; git stash push --include-untracked -m 'auto-stash'; $didStash = (@(git stash list).Count -gt $preCount); git pull --rebase; if ($didStash) { git stash pop }; git add --all; git diff --cached --quiet; if ($LASTEXITCODE -ne 0) { git commit }; git push -u origin HEAD; Write-Host ''; git status; Write-Host ''
+~~~
+
+### Read-only inspection
+
+#### Show what SSH keys and username git thinks you're using
+
+~~~pwsh
+Write-Host "`ngit will be using this contact info:"; git config user.name; git config user.email; Write-Host "`ngit remote info:"; git remote -v; Write-Host "`nSSH login test:"; ssh -T git@github.com; Write-Host ''; git status; Write-Host ''
+~~~
+
+#### Show diff between local state and upstream
+
+~~~pwsh
+git fetch; Write-Host ''; git status; Write-Host ''; git diff HEAD '@{u}'; Write-Host ''
+~~~
+
+git pages its own diff output, so there is no `less` in this one. To page it yourself instead, append `| Out-Host -Paging`.
+
+### Branches
+
+#### Check out an existing branch and start using it, while preserving local changes
+
+~~~pwsh
+$branchName = 'feature|bugfix/EXISTING_BRANCH_NAME'
+if ($branchName) { $preCount = @(git stash list).Count; git stash push --include-untracked -m 'auto-stash'; $didStash = (@(git stash list).Count -gt $preCount); git fetch origin && git checkout $branchName; if ($didStash) { git stash pop }; Write-Host ''; git status; Write-Host '' }
+~~~
+
+#### Create a new branch and sync it to GitHub
+
+~~~pwsh
+$branchName = 'feature|bugfix/NEW_BRANCH_NAME'
+if ($branchName) { $preCount = @(git stash list).Count; git stash push --include-untracked -m 'auto-stash'; $didStash = (@(git stash list).Count -gt $preCount); git pull --ff-only && git checkout -b $branchName; if ($didStash) { git stash pop }; git push -u origin $branchName && Write-Host '' && git branch -vv && Write-Host '' && git status && Write-Host '' }
+~~~
+
+#### Push current changes and switch to a different branch
+
+~~~pwsh
+$branchName = 'feature|bugfix/EXISTING_BRANCH_NAME'
+
+# Commit and push current branch, then switch
+git add --all; git diff --cached --quiet; if ($LASTEXITCODE -ne 0) { git commit }; git push -u origin HEAD
+if ($branchName) { git fetch origin && git checkout $branchName && git pull --ff-only && Write-Host '' && git branch -vv && Write-Host '' && git status && Write-Host '' }
+~~~
+
+#### Merge current local feature branch to main, and return to main
+
+~~~pwsh
+$branchName = 'feature|bugfix/EXISTING_BRANCH_NAME'
+
+# Commit local changes and sync with upstream
+$preCount = @(git stash list).Count; git stash push --include-untracked -m 'auto-stash'; $didStash = (@(git stash list).Count -gt $preCount); git pull --rebase; if ($didStash) { git stash pop }; git add --all; git diff --cached --quiet; if ($LASTEXITCODE -ne 0) { git commit }; git push -u origin HEAD; Write-Host ''; git status; Write-Host ''
+
+# Merge to main (assumes clean working tree - run preceding block first)
+if ($branchName) { git checkout main && git pull --ff-only origin main && git checkout $branchName && git merge main && git checkout main && git merge --no-ff $branchName && git push origin main && Write-Host '' && git branch -vv && Write-Host '' && git status && Write-Host '' }
+~~~
+
+### Maintenance
+
+#### Remove a file from git AND locally
+
+~~~pwsh
+$fileToDelete = 'FILE_TO_DELETE'
+if ($fileToDelete -and (Test-Path -LiteralPath $fileToDelete)) { git rm --cached -r $fileToDelete && git commit -m "Remove '${fileToDelete}' from tracking." && git push && Remove-Item -LiteralPath $fileToDelete -Recurse -Force }
+~~~
+
+Unlike the Bash version's `trash`, `Remove-Item` deletes outright - there is no cross-platform recycle bin from pwsh.
 
 ## References
 

--- a/project/backlog.md
+++ b/project/backlog.md
@@ -45,8 +45,6 @@ In each section, items are listed approximately from newest to oldest.
 
 ### Features and enhancements
 
-- 🔘 'git_notes_and_oneliners.md': Move the current commands under a "Bash" section, and add a "PowerShell" section below it, with pwsh v7 parity versions of the same one-liners.
-
 - 🛠️ CICD process (full spec in private notes):
 
 	- ✅ `cicd.bash`: `-q|--quiet`, `-m|--msg|--message`, prompt for commit message when neither given (CTRL+C aborts); silkterm output style; `fEcho`/`fParseArgs` conventions.
@@ -111,6 +109,12 @@ In each section, items are listed approximately from newest to oldest.
 #### Done - Bugs
 
 #### Done - Features and enhancements
+
+- ✅ 'git_notes_and_oneliners.md': Move the current commands under a "Bash" section, and add a "PowerShell" section below it, with pwsh v7 parity versions of the same one-liners.
+	- Two mirrored sections, same task headings in the same order, so the two are easy to compare side by side.
+	- The PowerShell section opens with the three gotchas that bite when translating from Bash: `&&`/`||` need pwsh 7, `@{u}` has to be quoted, and staged-change tests read `$LASTEXITCODE`.
+	- Every pwsh one-liner was run against throwaway repos, not just eyeballed. Two spots deviate on purpose: no `less` (git pages its own diff), and `Remove-Item` deletes outright since there is no cross-platform `trash`.
+	- Also swapped the stale sister-tool reference in the Bash "push local changes" one-liner for `gitsby saveup`.
 
 - ✅ All potentially destructive or conflict-producing commands - or anything that will reveal a user identity on the remote - should:
 	- Show what's going to change (including a list of changed files, piped through an internal equivalent of `... | less -FX` if necessary)


### PR DESCRIPTION
Splits git_notes_and_oneliners.md into mirrored Bash and PowerShell sections; pwsh 7 versions of every one-liner, verified against throwaway repos.