### PR TITLE
update verb, release ff, output spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ There are many implicit opinions baked in. Here are the main ones:
 
 - Commit the whole working tree (`git add --all`), every time. The staging area is not a workspace; partial staging is one of those fringe cases left to raw `git`.
 
-- Commit and pull frequently (`saveup`); push less often (`sync`).
+- Commit and pull frequently (`update`); push less often (`sync`).
 
 - Uncommitted work should never block anything. A pull auto-stashes around itself (untracked files included), and a branch switch parks current work first - commit, pull, push - so nothing is ever stranded or lost.
 

--- a/bin/gitsby
+++ b/bin/gitsby
@@ -45,7 +45,7 @@ fAbout(){ { ((doQuietly)) || ((wasShown_About)); } && return; wasShown_About=1;
 fSyntax(){ { ((doQuietly)) || ((wasShown_Syntax)); } && return; wasShown_Syntax=1;
 	fEcho_Clean ""
 	fEcho_Clean "Common commands:"
-	fEcho_Clean "  saveup [msg] ...: Commit all local changes and pull updates. Do frequently!"
+	fEcho_Clean "  update [msg] ...: Commit all local changes and pull updates. Do frequently!"
 	fEcho_Clean "  newbr <branch> .: Create a new branch off ${mergeTargetLabel} (parks current work first)."
 	fEcho_Clean "  gobr [branch] ..: Switch to a branch (parks current work first). No arg: back to ${mergeTargetLabel}."
 	fEcho_Clean "  status .........: Fetch and show current status."
@@ -79,6 +79,9 @@ fMain(){
 		*" -v "*|*" --ver "*|*" --version "*)  fCopyright;                  return 0; ;;
 	esac
 
+	## Breathing room after the shell prompt (the matching trailing blank is at each exit path).
+	fEcho_Clean ""
+
 	## Validate dependencies
 	fMustBeInPath git
 
@@ -98,7 +101,8 @@ fMain(){
 	case "${cmdName}" in
 		scommit)  cmdName="commit" ;;
 		spull)    cmdName="pull"   ;;
-		scompul)  cmdName="saveup" ;;
+		scompul)  cmdName="update" ;;
+		saveup)   cmdName="update" ;;
 		spush)    cmdName="sync"   ;;
 		mkbranch) cmdName="newbr"  ;;
 		chbranch) cmdName="gobr"   ;;
@@ -111,7 +115,7 @@ fMain(){
 	case "${cmdName}" in
 		status|listbr)           isMutating=0 ;;
 		pr)                      [[ "${cmdArg,,}" == "ok" ]] || isMutating=0 ;;
-		commit|saveup|sync|land) [[ -z "${commitMessage}" ]] && commitMessage="${cmdArg}" ;;
+		commit|update|sync|land) [[ -z "${commitMessage}" ]] && commitMessage="${cmdArg}" ;;
 		pull|newbr|gobr|release) : ;;
 		*) fThrowError "Unknown command '${cmdName}'. Run '${meName}' with no arguments for a list." ;;
 	esac
@@ -167,7 +171,7 @@ fMain(){
 	case "${cmdName}" in
 		commit)  fCmdCommit ;;
 		pull)    fCmdPull ;;
-		saveup)  fCmdCommitPull ;;
+		update)  fCmdCommitPull ;;
 		sync)    fCmdPush ;;
 		newbr)   fCmdNewBranch "${cmdArg}" ;;
 		gobr)    fCmdGoBranch "${cmdArg}" ;;
@@ -333,8 +337,19 @@ fCmdRelease(){
 		fHasUpstream && fRun git push
 		fRun git push origin "${releaseTag}"
 	fi
+	## Fast-forward dev to include the release merge and tag, so dev isn't left a commit behind.
+	## ff-only (not branch -f): if dev moved mid-release, skip rather than discard work.
+	if [[ -n "${devBranch}" ]]; then
+		if git merge-base --is-ancestor "${devBranch}" "${mainBranch}"; then
+			fRun git checkout "${devBranch}"
+			fRun git merge --ff-only "${mainBranch}"
+			fHasUpstream && fRun git push
+		else
+			fEcho "WARNING: '${devBranch}' gained commits during the release; leaving it as-is."
+		fi
+	fi
 	## Don't leave the user parked on main.
-	if [[ -n "${startBranch}" && "${startBranch}" != "${mainBranch}" ]]; then
+	if [[ -n "${startBranch}" && "${startBranch}" != "$(fCurrentBranch)" && "${startBranch}" != "${mainBranch}" ]]; then
 		fRun git checkout "${startBranch}"
 	fi
 :;}
@@ -518,12 +533,12 @@ fpPreview(){
 			fEcho_Clean "${p}git pull --ff-only *"
 			fEcho_Clean "${p}git stash pop *"
 			;;
-		saveup)
+		update)
 			fpPreview commit
 			fpPreview pull
 			;;
 		sync)
-			fpPreview saveup
+			fpPreview update
 			fEcho_Clean "${p}git push *"
 			;;
 		newbr)
@@ -565,6 +580,11 @@ fpPreview(){
 			fEcho_Clean "${p}git tag -a ${releaseTag}"
 			fEcho_Clean "${p}git push *"
 			fEcho_Clean "${p}git push origin ${releaseTag} *"
+			if [[ "$(fMergeTarget)" == "dev" ]]; then
+				fEcho_Clean "${p}git checkout dev *"
+				fEcho_Clean "${p}git merge --ff-only $(fDefaultBranch) *"
+				fEcho_Clean "${p}git push *"
+			fi
 			fEcho_Clean "${p}git checkout $(fCurrentBranch) *"
 			;;
 	esac
@@ -813,3 +833,7 @@ declare -i isSourced; { (return 0 2>/dev/null) && isSourced=1; } || isSourced=0
 ##		- 20260723 JC:
 ##			- Pre-flight display before the confirm prompt: resolved SSH identity (alias -> real host, user, key), commit author, ahead/behind, and the files an incoming pull would change.
 ##			- Changed files now list one per line, truncated to the terminal and capped, instead of git status's long form.
+##		- 20260723 JC:
+##			- Renamed saveup->update (saveup stays as a hidden alias).
+##			- release now fast-forwards dev to main afterward so dev includes the release merge and tag; skipped (with a warning) if dev moved mid-release.
+##			- Output starts with a blank line for breathing room after the shell prompt.

--- a/bin/gitsby.ps1
+++ b/bin/gitsby.ps1
@@ -8,10 +8,10 @@
     acting (stash only if dirty, pull only with an upstream, push only if
     ahead), so each is idempotent and safe to re-run.
 .PARAMETER Command
-    saveup | newbr | gobr | status | listbr | sync | pull | commit | land | pr | release
-    (old names scompul/mkbranch/chbranch/list/spush/spull/scommit/mtm still work)
+    update | newbr | gobr | status | listbr | sync | pull | commit | land | pr | release
+    (old names saveup/scompul/mkbranch/chbranch/list/spush/spull/scommit/mtm still work)
 .PARAMETER CommandArg
-    Message (commit/saveup/sync/land), branch name (newbr/gobr), version (release),
+    Message (commit/update/sync/land), branch name (newbr/gobr), version (release),
     or PR number / 'ok' (pr).
 .PARAMETER CommandArg2
     PR number, for 'pr ok <n>'.
@@ -20,7 +20,7 @@
 .PARAMETER Quiet
     No prompts; if committing with no message, one is generated.
 .EXAMPLE
-    gitsby.ps1 saveup "fixed the frobnicator"
+    gitsby.ps1 update "fixed the frobnicator"
 .EXAMPLE
     gitsby.ps1 newbr featx
 .NOTES
@@ -117,7 +117,7 @@ function Show-Syntax {
     $script:wasShownSyntax = $true
     Write-PlainLine ''
     Write-PlainLine 'Common commands:'
-    Write-PlainLine '  saveup [msg] ...: Commit all local changes and pull updates. Do frequently!'
+    Write-PlainLine '  update [msg] ...: Commit all local changes and pull updates. Do frequently!'
     Write-PlainLine "  newbr <branch> .: Create a new branch off ${script:mergeTargetLabel} (parks current work first)."
     Write-PlainLine "  gobr [branch] ..: Switch to a branch (parks current work first). No arg: back to ${script:mergeTargetLabel}."
     Write-PlainLine '  status .........: Fetch and show current status.'
@@ -360,13 +360,13 @@ function Show-CommandPreview {
             Write-PlainLine "${pad}git stash pop *"
             break
         }
-        'saveup' {
+        'update' {
             Show-CommandPreview -CommandName 'commit'
             Show-CommandPreview -CommandName 'pull'
             break
         }
         'sync' {
-            Show-CommandPreview -CommandName 'saveup'
+            Show-CommandPreview -CommandName 'update'
             Write-PlainLine "${pad}git push *"
             break
         }
@@ -414,6 +414,11 @@ function Show-CommandPreview {
             Write-PlainLine "${pad}git tag -a $($script:releaseTag)"
             Write-PlainLine "${pad}git push *"
             Write-PlainLine "${pad}git push origin $($script:releaseTag) *"
+            if ((Get-MergeTarget) -eq 'dev') {
+                Write-PlainLine "${pad}git checkout dev *"
+                Write-PlainLine "${pad}git merge --ff-only $(Get-DefaultBranch) *"
+                Write-PlainLine "${pad}git push *"
+            }
             Write-PlainLine "${pad}git checkout $(Get-CurrentBranch) *"
             break
         }
@@ -581,8 +586,20 @@ function Invoke-GitsbyRelease {
         if (Test-GitUpstream) { Invoke-Git -GitArgs @('push') }
         Invoke-Git -GitArgs @('push', 'origin', $script:releaseTag)
     }
+    ## Fast-forward dev to include the release merge and tag, so dev isn't left a commit behind.
+    ## ff-only (not branch -f): if dev moved mid-release, skip rather than discard work.
+    if ($devBranch) {
+        git merge-base --is-ancestor $devBranch $mainBranch *> $null
+        if ($LASTEXITCODE -eq 0) {
+            Invoke-Git -GitArgs @('checkout', $devBranch)
+            Invoke-Git -GitArgs @('merge', '--ff-only', $mainBranch)
+            if (Test-GitUpstream) { Invoke-Git -GitArgs @('push') }
+        } else {
+            Write-StatusLine "WARNING: '${devBranch}' gained commits during the release; leaving it as-is."
+        }
+    }
     ## Don't leave the user parked on main.
-    if ($startBranch -and ($startBranch -ne $mainBranch)) { Invoke-Git -GitArgs @('checkout', $startBranch) }
+    if ($startBranch -and ($startBranch -ne (Get-CurrentBranch)) -and ($startBranch -ne $mainBranch)) { Invoke-Git -GitArgs @('checkout', $startBranch) }
 }
 
 
@@ -597,6 +614,9 @@ try {
     if ($Help) { Show-Copyright; Show-About; Show-Syntax; exit 0 }
     if ($Version) { Show-Copyright; exit 0 }
     if (-not $Command) { Show-Copyright; Show-About; Show-Syntax; exit 1 }
+
+    ## Breathing room after the shell prompt (the matching trailing blank is at each exit path).
+    Write-PlainLine ''
 
     if (-not (Get-Command -Name git -ErrorAction SilentlyContinue)) { throw 'Not found in path: git' }
 
@@ -613,7 +633,8 @@ try {
     $cmdName = switch ($cmdName) {
         'scommit' { 'commit'; break }
         'spull' { 'pull'; break }
-        'scompul' { 'saveup'; break }
+        'scompul' { 'update'; break }
+        'saveup' { 'update'; break }
         'spush' { 'sync'; break }
         'mkbranch' { 'newbr'; break }
         'chbranch' { 'gobr'; break }
@@ -627,7 +648,7 @@ try {
     switch ($cmdName) {
         { $_ -in 'status', 'listbr' } { $isMutating = $false; break }
         'pr' { if ($CommandArg.ToLowerInvariant() -ne 'ok') { $isMutating = $false }; break }
-        { $_ -in 'commit', 'saveup', 'sync', 'land' } { if (-not $script:commitMessage) { $script:commitMessage = $CommandArg }; break }
+        { $_ -in 'commit', 'update', 'sync', 'land' } { if (-not $script:commitMessage) { $script:commitMessage = $CommandArg }; break }
         { $_ -in 'pull', 'newbr', 'gobr', 'release' } { break }
         default { throw "Unknown command '${cmdName}'. Run '${script:meName}' with no arguments for a list." }
     }
@@ -687,7 +708,7 @@ try {
     switch ($cmdName) {
         'commit' { Invoke-GitsbyCommit; break }
         'pull' { Invoke-GitsbyPull; break }
-        'saveup' { Invoke-GitsbyCommitPull; break }
+        'update' { Invoke-GitsbyCommitPull; break }
         'sync' { Invoke-GitsbyPush; break }
         'newbr' { Invoke-GitsbyMakeBranch -NewBranch $CommandArg; break }
         'gobr' { Invoke-GitsbyChangeBranch -TargetBranch $CommandArg; break }
@@ -713,3 +734,4 @@ try {
 ##      - 20260722 JC: Created; port of bin/gitsby (same commands, checks, and flow).
 ##      - 20260722 JC: Command renames (old names stay as hidden aliases), dev-aware merge target, pr and release commands - in step with bin/gitsby.
 ##      - 20260723 JC: Pre-flight display (SSH identity, commit author, ahead/behind, incoming files) and the capped short-form change list - in step with bin/gitsby.
+##      - 20260723 JC: Renamed saveup->update (old name aliased); release fast-forwards dev to main afterward; leading blank line on output - in step with bin/gitsby.

--- a/changelog.md
+++ b/changelog.md
@@ -28,7 +28,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- Renamed commands: `scompul`->`saveup`, `spush`->`sync`, `scommit`->`commit`, `spull`->`pull`, `mkbranch`->`newbr`, `chbranch`->`gobr`, `list`->`listbr`, `mtm`->`land`. The old names still work.
+- Renamed commands: `scompul`->`update`, `spush`->`sync`, `scommit`->`commit`, `spull`->`pull`, `mkbranch`->`newbr`, `chbranch`->`gobr`, `list`->`listbr`, `mtm`->`land`. The old names still work (as does the interim name `saveup`).
+- `release` now fast-forwards dev to main afterward, so dev includes the release merge and tag. If dev gained commits mid-release, the fast-forward is skipped with a warning instead of discarding anything.
+- Output starts and ends with a blank line, for breathing room between shell prompts.
 - Status now shows a compact one-line-per-file change list instead of `git status`'s long form, truncated to the terminal width and capped so a large working tree can't scroll the prompt out of view.
 - `newbr`, `gobr`, and `land` now branch off / land on `dev` when the repo has one, else the default branch. `land` refuses to run from the default branch.
 

--- a/cicd/test.bash
+++ b/cicd/test.bash
@@ -89,6 +89,12 @@ fRunSuite(){
 	( cd "${cloneA}" && echo alias > alias.txt )
 	fAssert "old alias 'scommit' still works"  bash -c "cd '${cloneA}' && '${gitsby}' -q scommit 'via alias'"
 
+	## update: commit + pull in one; old name still works
+	( cd "${cloneA}" && echo upd > upd.txt )
+	fAssert "update commits and pulls"        bash -c "cd '${cloneA}' && '${gitsby}' -q update 'add upd'"
+	fAssert "worktree clean after update"     bash -c "cd '${cloneA}' && [[ -z \"\$(git status --porcelain)\" ]]"
+	fAssert "old alias 'saveup' still works"  bash -c "cd '${cloneA}' && '${gitsby}' -q saveup"
+
 	## sync: publishes; remote matches local
 	fAssert "sync runs"            bash -c "cd '${cloneA}' && '${gitsby}' -q sync 'push file2'"
 	fAssert "remote main matches"  bash -c "cd '${cloneA}' && [[ \"\$(git rev-parse main)\" == \"\$(git rev-parse origin/main)\" ]]"
@@ -153,6 +159,8 @@ fRunSuite(){
 	fAssert "release merged dev to main"  bash -c "cd '${cloneA}' && git ls-tree --name-only main | grep -qx feat2.txt"
 	fAssert "main pushed with tag"      bash -c "cd '${cloneA}' && [[ \"\$(git rev-parse main)\" == \"\$(git rev-parse origin/main)\" ]] && git ls-remote --tags origin | grep -q 'refs/tags/v1.2.3'"
 	fAssert "back on dev after release"  bash -c "cd '${cloneA}' && [[ \"\$(git branch --show-current)\" == dev ]]"
+	fAssert "dev fast-forwarded to the release"  bash -c "cd '${cloneA}' && [[ \"\$(git rev-parse dev)\" == \"\$(git rev-parse main)\" ]]"
+	fAssert "dev pushed after release"           bash -c "cd '${cloneA}' && [[ \"\$(git rev-parse dev)\" == \"\$(git rev-parse origin/dev)\" ]]"
 	fAssertFail "release same version rejected"  bash -c "cd '${cloneA}' && '${gitsby}' -q release 1.2.3"
 	fAssertFail "release bad version rejected"   bash -c "cd '${cloneA}' && '${gitsby}' -q release bogus"
 	( cd "${cloneA}" && echo more > more.txt )
@@ -196,3 +204,4 @@ echo "passed: ${pass}, failed: ${fail}"
 ##	History:
 ##		- 20260722 JC: Created, alongside the bin/gitsby refactor.
 ##		- 20260722 JC: Run the suite per implementation; added the pwsh leg.
+##		- 20260723 JC: Checks for the update command (and its old name), and for dev fast-forwarding after a release.

--- a/git_notes_and_oneliners.md
+++ b/git_notes_and_oneliners.md
@@ -104,7 +104,7 @@ preCount=$(git stash list | wc -l); git stash push --include-untracked -m "auto-
 #### Push local changes to upstream
 
 ~~~bash
-gitsby saveup
+gitsby update
 ~~~
 
 or
@@ -219,7 +219,7 @@ $preCount = @(git stash list).Count; git stash push --include-untracked -m 'auto
 #### Push local changes to upstream
 
 ~~~pwsh
-gitsby.ps1 saveup
+gitsby.ps1 update
 ~~~
 
 or

--- a/project/backlog.md
+++ b/project/backlog.md
@@ -56,7 +56,7 @@ In each section, items are listed approximately from newest to oldest.
 		- Both legs live since the pwsh port landed.
 
 	- ✅ Regression tests; keep updated as features/bugs land.
-		- `cicd/test.bash`: throwaway repos (bare origin + two clones), every command plus failure guards, run once per implementation - 130 checks.
+		- `cicd/test.bash`: throwaway repos (bare origin + two clones), every command plus failure guards, run once per implementation - 140 checks.
 
 	- 🛠️ Adversarial fuzz/security testing (our input surface + what we depend on).
 		- Stage wired (`cicd/fuzz.bash`); same timing as the test harness.
@@ -109,6 +109,15 @@ In each section, items are listed approximately from newest to oldest.
 #### Done - Bugs
 
 #### Done - Features and enhancements
+
+- ✅ Rename `saveup` to `update`.
+	- Done in both implementations; `saveup` stays as a hidden alias like the other old names. Docs and changelog swept.
+
+- ✅ Script output starts and ends with a blank line (breathing room between prompt text).
+	- Trailing blanks already existed on every exit path; added the leading one (both implementations). Error paths were already blank-wrapped.
+
+- ✅ After `release` merges dev to main, bring dev up to include the release merge and tag.
+	- Done via `git merge --ff-only main` on dev (then push), not `git branch -f dev main`: same result normally, but if dev gained commits mid-release it skips with a warning instead of discarding work. Previews updated; tests cover it.
 
 - ✅ 'git_notes_and_oneliners.md': Move the current commands under a "Bash" section, and add a "PowerShell" section below it, with pwsh v7 parity versions of the same one-liners.
 	- Two mirrored sections, same task headings in the same order, so the two are easy to compare side by side.


### PR DESCRIPTION
Rename saveup->update (old name aliased), fast-forward dev after a release, blank line at start of output.