### PR TITLE
fuzz harness

### DIFF
--- a/bin/gitsby.ps1
+++ b/bin/gitsby.ps1
@@ -611,7 +611,7 @@ function Invoke-GitsbyLand {
 function Invoke-GitsbyClone {
     Invoke-Git -GitArgs @('clone', $script:cloneUrl, $script:cloneDir)
     ## Opinionated: if the repo works dev-first, start there.
-    git -C $script:cloneDir show-ref --verify --quiet refs/remotes/origin/dev *> $null
+    git -C "$script:cloneDir" show-ref --verify --quiet refs/remotes/origin/dev *> $null
     if ($LASTEXITCODE -eq 0) { Invoke-Git -GitArgs @('-C', $script:cloneDir, 'checkout', 'dev') }
 }
 
@@ -622,7 +622,7 @@ function Invoke-GitsbyConnect {
         'create' {
             Write-PlainLine ''
             Write-StatusLine "gh repo create $($script:ghTarget) --$($script:repoVisibility) --source . --push --remote origin ..."
-            gh repo create $script:ghTarget "--$($script:repoVisibility)" --source . --push --remote origin
+            gh repo create "$script:ghTarget" "--$($script:repoVisibility)" --source . --push --remote origin
             if ($LASTEXITCODE -ne 0) { throw "'gh repo create' failed (exit ${LASTEXITCODE})." }
             Clear-BlankCounter
             break
@@ -830,7 +830,7 @@ try {
     ## Branch arguments validate up front too, so a bad name can't survive to a nonsense preview.
     if ($cmdName -eq 'newbr') {
         if (-not $CommandArg) { throw "No branch name given. Syntax: ${script:meName} newbr <new branch name>" }
-        git check-ref-format --branch $CommandArg *> $null
+        git check-ref-format --branch "$CommandArg" *> $null  ## quote: a bare $var lets PowerShell glob '*'/'?' to filenames, defeating the check
         if ($LASTEXITCODE -ne 0) { throw "'${CommandArg}' is not a valid branch name." }
         if (Test-GitBranchLocal -Branch $CommandArg) { throw "Branch '${CommandArg}' already exists; use: ${script:meName} gobr ${CommandArg}" }
         if (Test-GitBranchRemote -Branch $CommandArg) { throw "Branch '${CommandArg}' already exists on origin; use: ${script:meName} gobr ${CommandArg}" }
@@ -851,7 +851,7 @@ try {
             if (-not $script:cloneDir) { throw "Can't derive a directory name from '$($script:cloneUrl)'; give one explicitly." }
         }
         if (Test-Path -LiteralPath $script:cloneDir) {
-            $existingUrl = git -C $script:cloneDir remote get-url origin 2>$null
+            $existingUrl = git -C "$script:cloneDir" remote get-url origin 2>$null
             if ($LASTEXITCODE -ne 0 -or $null -eq $existingUrl) { $existingUrl = '' }
             if ((Test-Path -LiteralPath (Join-Path -Path $script:cloneDir -ChildPath '.git')) -and (([string]$existingUrl) -ceq $script:cloneUrl)) {
                 Write-StatusLine "'$($script:cloneDir)' is already a clone of that URL; nothing to do."
@@ -887,7 +887,7 @@ try {
                 ## owner/name shorthand: the gh path - create the repo if it doesn't exist yet.
                 if (-not (Get-Command -Name gh -ErrorAction SilentlyContinue)) { throw 'Not found in path: gh' }
                 $script:ghTarget = $CommandArg
-                $isEmpty = gh repo view $script:ghTarget --json isEmpty --jq .isEmpty 2>$null
+                $isEmpty = gh repo view "$script:ghTarget" --json isEmpty --jq .isEmpty 2>$null
                 if ($LASTEXITCODE -ne 0 -or -not $isEmpty) {
                     $script:connectMode = 'create'
                 } elseif (([string]$isEmpty).Trim() -eq 'true') {

--- a/cicd/cicd.bash
+++ b/cicd/cicd.bash
@@ -278,7 +278,7 @@ elif [[ -f "${FUZZ_CMD[0]:-}" ]]; then
 	"${FUZZ_CMD[@]}"
 	fEcho "OK: fuzz + security passed"
 else
-	fEcho_Clean "no fuzz harness yet (${FUZZ_CMD[0]:-cicd/fuzz.bash} - lands with the bin/gitsby refactor)"
+	fEcho_Clean "no fuzz harness (${FUZZ_CMD[0]:-cicd/fuzz.bash})"
 fi
 
 ## Stage 4: dogfood. A script project's "release build" is the script itself;

--- a/cicd/config.bash
+++ b/cicd/config.bash
@@ -57,8 +57,8 @@ PS_LINT_GLOBS=(
 ## until the file exists the engine reports the stage absent (not passing).
 TEST_CMD=(cicd/test.bash)
 
-## Stage 3: fuzz + security (adversarial input against gitsby's option/arg
-## parsing and repo-state handling). Same lands-later policy; skipped by --quick.
+## Stage 3: fuzz + security (adversarial input against gitsby's own command/option/
+## arg surface, with an injection canary; per implementation). Skipped by --quick.
 FUZZ_CMD=(cicd/fuzz.bash)
 
 ## Full run output is tee'd here (gitignored) so warnings from any stage can be

--- a/cicd/fuzz.bash
+++ b/cicd/fuzz.bash
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+##	Purpose:
+##		- Adversarial fuzz + injection-safety for gitsby's OWN input surface: the
+##		  command slot, options, and branch/message/version/pr arguments. Not
+##		  upstream git - just what a hostile or fat-fingered user can hand gitsby.
+##		- Three invariants, checked per vector, per implementation (bash always,
+##		  pwsh when installed):
+##		    1. No internal crash - no bash/pwsh error dump, exit stays a controlled 0/1.
+##		    2. No shell/command injection - a canary side-effect never fires.
+##		    3. Inputs that must be refused exit nonzero and leave the repo untouched.
+##		- Run by cicd.bash stage 3, or standalone. Hermetic: throwaway repos, no net.
+##	History: At bottom of script.
+
+##	Copyright © 2026 Jim Collier (ID: 1cv◂‡Vᛦ)
+##	Licensed under The MIT License (MIT). Full text at:
+##		https://mit-license.org/
+##	SPDX-License-Identifier: MIT
+
+
+set -Eeuo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "${here}/.." && pwd)"
+work="$(mktemp -d "${TMPDIR:-/tmp}/gitsby-fuzz.XXXXXX")"
+trap 'rm -rf "${work}"' EXIT
+
+## Hermetic: no reliance on (or writes to) the user's git config, no prompts.
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+export GIT_AUTHOR_NAME=fuzz GIT_AUTHOR_EMAIL=fuzz@fuzz
+export GIT_COMMITTER_NAME=fuzz GIT_COMMITTER_EMAIL=fuzz@fuzz
+export GIT_TERMINAL_PROMPT=0
+
+declare -i pass=0 fail=0
+fOk(){   pass=$((pass+1)); echo "  ok: $*"; }
+fFail(){ fail=$((fail+1)); echo "  FAIL: $*"; }
+
+## An internal-error dump from either implementation. A clean validation refusal
+## ("gitsby: <msg>", exit 1) matches none of these; an uncaught bash error, a
+## non-0/1 exit dump, or a pwsh StrictMode/runtime fault does. The arg parser's
+## "Reverse call stack:" line is a deliberate refusal, not a crash, so it's out.
+_crashRe='unbound variable|: syntax error|bad substitution|command not found|integer expression expected|not a valid identifier|divide by zero|division by 0|bad array subscript|: line [0-9]+:|At line# |Command# \.\.\.|Err# \.\.\.|cannot be retrieved because it has not been set|Cannot index into a null|Attempted to divide by zero|Method invocation failed|Unable to find type'
+
+_out=""; declare -i _code=0
+## Run gitsby in a directory with the given args verbatim (no reshell of the
+## vector), capturing merged output and exit code without tripping set -e.
+fRun(){
+	local -r dir="$1"; shift
+	_out="$( { cd "${dir}" && "${gitsby}" "$@"; } </dev/null 2>&1 )" && _code=0 || _code=$?
+}
+_isCrash(){ grep -qE "${_crashRe}" <<< "${_out}" || ((_code >= 2)); }
+
+## Must survive (accept or refuse - either is fine) without an internal crash.
+fSurvive(){ local -r desc="$1"; local -r dir="$2"; shift 2; fRun "${dir}" "$@"
+	if _isCrash; then fFail "${desc} (exit ${_code})"; else fOk "${desc}"; fi; }
+## Must refuse: nonzero exit, no crash.
+fRefuse(){ local -r desc="$1"; local -r dir="$2"; shift 2; fRun "${dir}" "$@"
+	if _isCrash; then fFail "${desc}: crashed (exit ${_code})"
+	elif ((_code == 0)); then fFail "${desc}: accepted, should refuse"
+	else fOk "${desc}"; fi; }
+
+## Fresh repo (bare origin + clone with one commit) under work/<name>.
+fMakeRepo(){
+	local -r dir="$1"
+	git init --quiet --bare -b main "${dir}.git"
+	git clone --quiet "${dir}.git" "${dir}" 2>/dev/null
+	( cd "${dir}" && echo seed > seed.txt && git add --all \
+		&& git commit --quiet -m seed && git push --quiet -u origin main )
+}
+
+## Vectors. None of these strings contain a _crashRe keyword, so a vector echoed
+## back in gitsby's output can't self-trip the crash check.
+## The single quotes are the point: these must reach gitsby as literal text, not
+## expand here - that's what proves gitsby keeps them inert.
+# shellcheck disable=SC2016
+{
+## Commands are matched case-insensitively (forgiving by design), so 'STATUS' is a
+## valid alias of 'status' and doesn't belong here.
+badCommands=( frobnicate status2 '..' './x' '123' 'a b' '-' '--' 'commit extra junk' )
+badOptions=( --bogus -x -qx '--no-fetch=1' '--=v' -Z )
+inject=( '$(touch CANARY_A)' '`touch CANARY_B`' ';touch CANARY_C' '&& touch CANARY_D'
+         '| touch CANARY_E' '> CANARY_F' '$(touch CANARY_G)tail' '../CANARY_H' )
+badBranch=( "${inject[@]}" 'a..b' 'has space' '-leadingdash' 'tilde~x' 'caret^x'
+            'colon:x' 'ends.lock' '/leading' 'trailing/' 'back\slash' '?' '*' )
+## 'v1.2.3' (leading v stripped) and 'X.Y.Z.W' (matches the optional suffix) are
+## valid on purpose, so they belong nowhere near this refuse list.
+badVersion=( not.a.version 1 1.2 'v.1.2' '1.2.3-' '-1.0.0' '$(touch CANARY_V)' 'x y' )
+badPr=( abc 3.5 '$(touch CANARY_P)' 'x' 'ok' 'ok abc' 'ok 1 2' )
+}
+
+## The whole fuzz suite against whatever ${gitsby} points at.
+fRunFuzz(){
+	echo "fuzz: $1 (${gitsby})"
+	local -r base="${work}/$1"
+	mkdir -p "${base}"
+
+	## Command slot: garbage first tokens are refused, never crash.
+	local repo="${base}/cmd"; fMakeRepo "${repo}"
+	local c
+	for c in "${badCommands[@]}"; do fRefuse "command refused: '${c}'" "${repo}" -q "${c}"; done
+
+	## Options: unknown ones refused in either slot; valid combos accepted.
+	local o
+	for o in "${badOptions[@]}"; do
+		fRefuse "option refused (slot 1): '${o}'" "${repo}" -q "${o}" status
+		fRefuse "option refused (slot 2): '${o}'" "${repo}" -q status "${o}"
+	done
+	fSurvive "valid combo -q -y status"        "${repo}" -q -y status
+	fSurvive "valid combo -q --no-fetch status" "${repo}" -q --no-fetch status
+	fSurvive "valid combo -y -q listbr"        "${repo}" -y -q listbr
+
+	## Branch names: injection + malformed refs are refused before any action.
+	local b
+	for b in "${badBranch[@]}"; do
+		fRefuse "newbr refuses: '${b}'" "${repo}" -q newbr "${b}"
+		fRefuse "gobr refuses: '${b}'"  "${repo}" -q gobr  "${b}"
+	done
+
+	## Commit messages: anything goes in a message, but it stays inert data. Each
+	## needs a real change to reach 'git commit'; unique content guarantees one.
+	local repo2="${base}/msg"; fMakeRepo "${repo2}"
+	local -i i=0 m
+	for m in "${!inject[@]}"; do
+		echo "change ${i}" > "${repo2}/seed.txt"; i=$((i + 1))
+		fSurvive "commit message inert: '${inject[m]}'" "${repo2}" -q commit "${inject[m]}"
+	done
+
+	## Versions and PR numbers: malformed values refused (release fetches first,
+	## which is local here; pr rejects before any network).
+	local repo3="${base}/ver"; fMakeRepo "${repo3}"
+	local v p
+	for v in "${badVersion[@]}"; do fRefuse "release refuses version: '${v}'" "${repo3}" -q release "${v}"; done
+	for p in "${badPr[@]}";      do fRefuse "pr refuses: '${p}'"              "${repo3}" -q pr "${p}"; done
+
+	## Long and odd input: must not crash. Branch is refused, message accepted.
+	local long; long="$(printf 'x%.0s' {1..5000})"
+	fRefuse  "long branch refused"  "${repo3}" -q newbr "${long}"
+	echo odd > "${repo2}/seed.txt"
+	fSurvive "long message survives" "${repo2}" -q commit "${long}"
+	echo odd2 > "${repo2}/seed.txt"
+	fSurvive "unicode/emoji message" "${repo2}" -q commit $'café \u{1F600} ‮ rtl'
+
+	## No-mutate: a refused command leaves HEAD and branch exactly as they were.
+	local before_head before_branch
+	before_head="$(cd "${repo}" && git rev-parse HEAD)"
+	before_branch="$(cd "${repo}" && git branch --show-current)"
+	fRun "${repo}" -q newbr 'bad:name'   ## refused
+	if [[ "$(cd "${repo}" && git rev-parse HEAD)" == "${before_head}" \
+		&& "$(cd "${repo}" && git branch --show-current)" == "${before_branch}" ]]; then
+		fOk "refused command left the repo unchanged"
+	else
+		fFail "refused command mutated the repo"
+	fi
+}
+
+echo "gitsby fuzz + security (fixtures: ${work})"
+
+gitsby="${root}/bin/gitsby"
+fRunFuzz "bash"
+
+## Same suite against the PowerShell port when pwsh is present. The shim keeps
+## ${gitsby} a single path, so the argument passing above is unchanged.
+if command -v pwsh >/dev/null 2>&1; then
+	gitsby="${work}/gitsby-pwsh"
+	printf '#!/usr/bin/env bash\nexec pwsh -NoProfile -File "%s" "$@"\n' "${root}/bin/gitsby.ps1" > "${gitsby}"
+	chmod +x "${gitsby}"
+	fRunFuzz "pwsh"
+else
+	echo "fuzz: pwsh skipped (pwsh not installed)"
+fi
+
+## The security assertion: no vector ever caused a side-effect to run.
+if [[ -z "$(find "${work}" -name 'CANARY*' -print -quit)" ]]; then
+	fOk "no injection canary fired"
+else
+	fFail "injection canary fired: $(find "${work}" -name 'CANARY*')"
+fi
+
+echo "passed: ${pass}, failed: ${fail}"
+((fail == 0)) || exit 1
+
+
+##	History:
+##		- 20260724 JC: Created. Adversarial fuzz of the command/option/arg surface
+##			with an injection canary, run per implementation like the test harness.

--- a/project/backlog.md
+++ b/project/backlog.md
@@ -214,8 +214,11 @@ Items below came out of the 20260723 code review. Fix notes for every item: `des
 	- ✅ Regression tests; keep updated as features/bugs land.
 		- `cicd/test.bash`: throwaway repos (bare origin + two clones), every command plus failure guards, run once per implementation - 140 checks.
 
-	- 🛠️ Adversarial fuzz/security testing (our input surface + what we depend on).
-		- Stage wired (`cicd/fuzz.bash`); same timing as the test harness.
+	- ✅ Adversarial fuzz/security testing (our input surface + what we depend on).
+		- Done: `cicd/fuzz.bash` - bombards the command slot, options, and branch/message/version/pr args with malformed + injection vectors, per implementation (bash + pwsh). Asserts three invariants: no internal crash (bash/pwsh error-dump signatures), no shell/command injection (a canary side-effect never fires), and inputs-that-must-refuse exit nonzero leaving the repo unchanged. 183 checks. Found + fixed a real pwsh-port bug (see next item). Scope is gitsby's own input, not upstream git.
+		- Fuzz-found bug (fixed here): the pwsh port passed user-supplied values to native git UNquoted, so PowerShell wildcard-expanded `*`/`?` against the filesystem before git saw them - `newbr '*'` slipped past `check-ref-format` and created a branch named after a file. Quoted the user values in the direct git/gh calls (branch validation, clone-dir, gh target), mirroring the bash port. bash was never affected (always quoted).
+
+	- 🔘 pwsh: `Invoke-Git` splats an argument array (`git @GitArgs`), and PowerShell wildcard-expands any element that is a literal `*`/`?`/`[]` - so a commit message of exactly `*` could glob to a filename. Quoting array elements does NOT help (only direct, non-splat quoted args are glob-exempt). Needs a real fix (escape wildcards for native args, or route mutations so literals reach git intact), then add a bare-`*`/`?` commit-message vector to `cicd/fuzz.bash` to lock it. Lower severity than the validation bypass just fixed (data integrity, not a security gate).
 
 	- ✅ Automated demo GIF (fake terminal, `--quick` skips); copy `gen-demo-gif.py` from convert-base-v2; embed `assets/demo.gif` in README.
 		- Done: scenario `cicd/demo-scenario.toml` + repo builder `cicd/utility/demo-repo.bash`; embedded in README top with a commented YouTube placeholder. Single hero `land` command (state block + full plan + commit/push/merge/cleanup) in an anonymized throwaway repo built offline; runs real gitsby so it can't go stale. 960x540 (the tool's default, a blessed alternative in the private note; not 640x360, and the tool has no fixed-fps knob). Pinned commit dates make it byte-deterministic so cicd only regenerates on real change. 18.4s loop, 823 KiB.


### PR DESCRIPTION
Adversarial fuzz + injection-safety harness (cicd/fuzz.bash, 183 checks, per impl). Caught + fixed a pwsh-port glob validation bypass (unquoted user args to native git). Deeper Invoke-Git splat-glob logged as a follow-up.